### PR TITLE
FIX: Memory leak in adapter

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,7 +11,7 @@ internal object Versions {
     const val espresso = "3.3.0"
     const val dagger = "2.29.1"
     const val retrofit = "2.9.0"
-    const val leakCanary = "2.6"
+    const val leakCanary = "2.7"
     const val rxJava3 = "3.0.0"
     const val glide = "4.12.0"
     const val dependenciesChecker = "0.36.0"

--- a/feature_popular/src/main/java/com/tiago/popular/ui/PopularFragment.kt
+++ b/feature_popular/src/main/java/com/tiago/popular/ui/PopularFragment.kt
@@ -63,9 +63,9 @@ class PopularFragment : Fragment(R.layout.fragment_popular), MovieAdapterEvents 
         navigator.navigateTo(MoviesNavigation.Details(bundle, extras))
     }
 
-    override fun onDestroy() {
+    override fun onDestroyView() {
         adapter = null
-        super.onDestroy()
+        super.onDestroyView()
     }
 
     private fun injectDependencies() = PopularInjector.component.inject(this)

--- a/navigation/src/main/java/com/tiago/navigation/MoviesNavigator.kt
+++ b/navigation/src/main/java/com/tiago/navigation/MoviesNavigator.kt
@@ -6,6 +6,11 @@ class MoviesNavigator {
     lateinit var navController: NavController
 
     fun navigate(navigation: MoviesNavigation) = when(navigation) {
-        is MoviesNavigation.Details -> navController.navigate(R.id.action_popular_to_details, navigation.bundle, null, navigation.extras)
+        is MoviesNavigation.Details -> navController.navigate(
+            R.id.action_popular_to_details,
+            navigation.bundle,
+            null,
+            navigation.extras
+        )
     }
 }


### PR DESCRIPTION
### Description

`LeakCanary` pointed out that the `adapter` was holding a reference to `CoordinatorLayout` from `PopularFragment`. 

In order to fix that, I've just set the reference of the `adapter` to null at `onDestroyView()`.